### PR TITLE
Use nano windows base image

### DIFF
--- a/docker/Dockerfile.windows.amd64.1809.nano
+++ b/docker/Dockerfile.windows.amd64.1809.nano
@@ -1,0 +1,21 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:1809 as base
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+USER ContainerAdministrator
+
+ENV GODEBUG=netdns=go
+RUN mkdir /bin
+RUN Invoke-WebRequest https://releases.jfrog.io/artifactory/jfrog-cli/v2/2.10.0/jfrog-cli-windows-amd64/jfrog.exe -OutFile C:/bin/jfrog.exe
+
+FROM mcr.microsoft.com/powershell:nanoserver-1809
+COPY --from=base /bin /bin
+
+ADD release/windows/amd64/plugin C:/bin/drone-artifactory.exe
+
+# https://github.com/PowerShell/PowerShell/issues/6211#issuecomment-367477137
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\Program Files\PowerShell"
+
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+ENTRYPOINT [ "C:\\bin\\drone-artifactory.exe" ]


### PR DESCRIPTION
Currently, certificate issue is present in the nano windows server when used along with the artifactory. This needs to be sorted.