### PR TITLE
Updated ubi-minimal version and upgraded jfrog cli to v2 for linux

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: testing
 
 steps:
 - name: build
-  image: golang:1.17.11
+  image: golang:1.18
   commands:
   - go test ./...
   - sh scripts/build.sh
@@ -21,7 +21,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.11
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/amd64/plugin"
   environment:
@@ -34,7 +34,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.11
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/amd64/plugin"
   environment:
@@ -98,7 +98,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.11
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/arm64/plugin"
   environment:
@@ -111,7 +111,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.11
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/arm64/plugin"
   environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: testing
 
 steps:
 - name: build
-  image: golang:1.17.8
+  image: golang:1.17.11
   commands:
   - go test ./...
   - sh scripts/build.sh
@@ -21,7 +21,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.8
+  image: golang:1.17.11
   commands:
   - "go build -v -ldflags \"-X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/amd64/plugin"
   environment:
@@ -34,7 +34,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.8
+  image: golang:1.17.11
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/amd64/plugin"
   environment:
@@ -98,7 +98,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.8
+  image: golang:1.17.11
   commands:
   - "go build -v -ldflags \"-X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/arm64/plugin"
   environment:
@@ -111,7 +111,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.8
+  image: golang:1.17.11
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}\" -a -o release/linux/arm64/plugin"
   environment:

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -9,7 +9,8 @@ COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN apk add --update \
     curl \
     && rm -rf /var/cache/apk/*
-RUN curl -fL https://getcli.jfrog.io | sh /dev/stdin 1.53.1
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.18.2
+RUN mv ./jf ./jfrog
 RUN mv ./jfrog /usr/local/bin/
 RUN chmod +x /usr/local/bin/jfrog
 

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -3,6 +3,7 @@ RUN apk add -U --no-cache ca-certificates
 
 FROM alpine:3.15
 ENV GODEBUG netdns=go
+ENV CI=true
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Install jfrog cli with version 1.35.5
@@ -10,8 +11,7 @@ RUN apk add --update \
     curl \
     && rm -rf /var/cache/apk/*
 RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.18.2
-RUN mv ./jf ./jfrog
-RUN mv ./jfrog /usr/local/bin/
+RUN mv ./jf /usr/local/bin/jfrog
 RUN chmod +x /usr/local/bin/jfrog
 
 ADD release/linux/amd64/plugin /bin/

--- a/docker/Dockerfile.linux.ubi.amd64
+++ b/docker/Dockerfile.linux.ubi.amd64
@@ -1,13 +1,13 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
 ENV GODEBUG netdns=go
+ENV CI=true
 
 # Install jfrog cli with version 2.18.2
 RUN microdnf install curl ca-certificates  \
     && rm -rf /var/cache/yum \
     && microdnf clean all
 RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.18.2
-RUN mv ./jf ./jfrog
-RUN mv ./jfrog /usr/local/bin/
+RUN mv ./jf /usr/local/bin/jfrog
 RUN chmod +x /usr/local/bin/jfrog
 
 ADD release/linux/amd64/plugin /bin/

--- a/docker/Dockerfile.linux.ubi.amd64
+++ b/docker/Dockerfile.linux.ubi.amd64
@@ -1,11 +1,12 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
 ENV GODEBUG netdns=go
 
-# Install jfrog cli with version 1.53.1
+# Install jfrog cli with version 2.18.2
 RUN microdnf install curl ca-certificates  \
     && rm -rf /var/cache/yum \
     && microdnf clean all
-RUN curl -fL https://getcli.jfrog.io | sh /dev/stdin 1.53.1
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.18.2
+RUN mv ./jf ./jfrog
 RUN mv ./jfrog /usr/local/bin/
 RUN chmod +x /usr/local/bin/jfrog
 

--- a/docker/Dockerfile.linux.ubi.amd64
+++ b/docker/Dockerfile.linux.ubi.amd64
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751
 ENV GODEBUG netdns=go
 
 # Install jfrog cli with version 2.18.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drone/drone-artifactory
 
-go 1.17
+go 1.18
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -33,9 +33,6 @@ type Args struct {
 
 // Exec executes the plugin.
 func Exec(ctx context.Context, args Args) error {
-	// for jfrogv2 cli, to hide unwanted messages
-	os.Setenv("CI", "true");
-
 	// write code here
 	if args.URL == "" {
 		return fmt.Errorf("url needs to be set")

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -33,6 +33,9 @@ type Args struct {
 
 // Exec executes the plugin.
 func Exec(ctx context.Context, args Args) error {
+	// for jfrogv2 cli, to hide unwanted messages
+	os.Setenv("CI", "true");
+
 	// write code here
 	if args.URL == "" {
 		return fmt.Errorf("url needs to be set")


### PR DESCRIPTION
The automation suite for JFrog is passing successfully with the new updated images.

Reason for image update:
1. Security Reference Ticket - https://harness.atlassian.net/browse/SECAPP-258
2. To meet federal requirements for storing harness images.
