### PR TITLE
feat: spec

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -67,7 +67,7 @@ func Exec(ctx context.Context, args Args) error {
 	if args.Spec != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--spec=%s", args.Spec))
 		if args.SpecVars != "" {
-			cmdArgs = append(cmdArgs, fmt.Sprintf("--spec-vars=%s", args.SpecVars))
+			cmdArgs = append(cmdArgs, fmt.Sprintf("--spec-vars='%s'", args.SpecVars))
 		}
 	} else {
 		if args.Source == "" {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -32,6 +32,7 @@ type Args struct {
 	Retries     int    `envconfig:"PLUGIN_RETRIES"`
 	Flat        string `envconfig:"PLUGIN_FLAT"`
 	Spec        string `envconfig:"PLUGIN_SPEC"`
+	Threads     int    `envconfig:"PLUGIN_THREADS"`
 	SpecVars    string `envconfig:"PLUGIN_SPEC_VARS"`
 }
 
@@ -62,6 +63,10 @@ func Exec(ctx context.Context, args Args) error {
 
 	flat := parseBoolOrDefault(false, args.Flat)
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--flat=%s", strconv.FormatBool(flat)))
+
+	if args.Threads > 0 {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--threads=%d", args.Threads))
+	}
 
 	// Take in spec file or use source/target arguments
 	if args.Spec != "" {


### PR DESCRIPTION
Customer request: Support spec files for uploading large combinations of files to artifactory.

https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UploadingFiles
https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UsingFileSpecs

|flag|use|
|---|---|
|spec|Path to a file spec|
|spec-vars|List of variables in the form of "key1=value1;key2=value2;..." to be replaced in the File Spec. In the File Spec, the variables should be used as follows: ${key1}|

"In case the --spec option is used, the commands accepts no arguments."

I am having the customer test my release to verify it gets them the value they expect: https://hub.docker.com/r/rssnyder/artifactory

My local usage: https://app.harness.io/ng/#/account/wlgELJ0TTre5aZhzpt8gVA/cd/orgs/default/projects/development/pipelines/artifactory/deployments/vWxO0XRXRcStSvmYPu_Cdg/pipeline?storeType=INLINE

Customer usage: https://app.harness.io/ng/#/account/PJouQ0w0S4Cr8nIfe4jHPw/ci/orgs/Product_Development/projects/R360/pipelines/Build_ImportApi/executions/bAyY2MceQV2WXz7rJeEy4w/pipeline?connectorRef=bbonprem&repoName=R360-Current&branch=harness&storeType=REMOTE

also: exposed the threads option for large uploads