### PR TITLE
add target_props argument

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -35,6 +35,7 @@ type Args struct {
 	Spec            string `envconfig:"PLUGIN_SPEC"`
 	Threads         int    `envconfig:"PLUGIN_THREADS"`
 	SpecVars        string `envconfig:"PLUGIN_SPEC_VARS"`
+	TargetProps     string `envconfig:"PLUGIN_TARGET_PROPS"`
 	Insecure        string `envconfig:"PLUGIN_INSECURE"`
 	PEMFileContents string `envconfig:"PLUGIN_PEM_FILE_CONTENTS"`
 	PEMFilePath     string `envconfig:"PLUGIN_PEM_FILE_PATH"`
@@ -113,6 +114,9 @@ func Exec(ctx context.Context, args Args) error {
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--spec-vars='%s'", args.SpecVars))
 		}
 	} else {
+		if args.TargetProps != "" {
+			cmdArgs = append(cmdArgs, fmt.Sprintf("--target-props='%s'", args.TargetProps))
+		}
 		if args.Source == "" {
 			return fmt.Errorf("source file needs to be set")
 		}


### PR DESCRIPTION
Add the `--target-props` argument so matrix style uploads can happen. From the [docs](https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory#uploading-files):

> A list of Artifactory [properties](https://jfrog.com/help/r/jfrog-artifactory-documentation/Working-With-Jfrog-Properties) specified as "key=value" pairs separated by a semi-colon ( ; ) to be attached to the uploaded files. If any key can take several values, then each value is separated by a comma ( , ). For example, "key1=value1;key2=value21,value22;key3=value3".