### PR TITLE
CI-1502 - removing unused docker sock used for debugging

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -36,7 +36,4 @@ RUN chmod +x /usr/local/bin/jfrog
 # Add your custom plugin
 ADD release/linux/amd64/plugin /bin/
 
-# Expose Docker socket for CLI interaction
-VOLUME /var/run/docker.sock
-
 ENTRYPOINT ["/bin/plugin"]


### PR DESCRIPTION
Removing unused docker sock used for debugging.