### PR TITLE
fix: [CI-15024]: fixed y/n prompt with CI=true, setting jfrog cli to 2.68.0

### DIFF
--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -3,6 +3,7 @@ RUN apk add -U --no-cache ca-certificates
 
 FROM arm64v8/alpine:3.20
 ENV GODEBUG netdns=go
+ENV CI=true
 
 ARG JRE_VERSION=openjdk17
 ARG GRADLE_VERSION=8.3
@@ -28,7 +29,7 @@ RUN curl -fsSL https://services.gradle.org/distributions/gradle-${GRADLE_VERSION
     && ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle
 
 # Install JFrog CLI
-RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.52.9
+RUN curl -fL https://getcli.jfrog.io/v2-jf | sh /dev/stdin 2.68.0
 RUN mv ./jf /usr/local/bin/jfrog
 RUN chmod +x /usr/local/bin/jfrog
 


### PR DESCRIPTION
fix [CI-15024]: fixed arm64 y/n prompt with CI=true, setting jfrog cli to 2.68.0

[CI-15024]: https://harness.atlassian.net/browse/CI-15024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ